### PR TITLE
Fix func arguments unpacking for before callback

### DIFF
--- a/src/HierarchicalRBAC/HRBACServiceProvider.php
+++ b/src/HierarchicalRBAC/HRBACServiceProvider.php
@@ -47,7 +47,7 @@ class HRBACServiceProvider extends ServiceProvider {
     {
         $this->mergeConfigFrom( __DIR__.'/../config/config.php', $this->packageName);
 
-        \Gate::before(function ($user, $ability, $arguments) {
+        \Gate::before(function ($user, $ability, ...$arguments) {
             $class = config($this->packageName.'.rbacClass');
             $rbac = new $class();
             return $rbac->checkPermission($user, $ability, $arguments);


### PR DESCRIPTION
When Laravel calls Gate::before callbacks, it use call_user_func_array()
and array_merge() all arguments for that. If $arguments for callback is
array (and it is cause Laravel packing single argument) callback func have to
receive variable count of arguments.

Added ...$arguments unpacking to  Gate::before callback for passing
$arguments as array unitl testUsingUserMethod() that converts array to single
element if necessary.